### PR TITLE
Added BASE_URL constant to set the base URL to 'yts.ag'

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -1,7 +1,7 @@
 # Yify API
 ### A simple PHP wrapper for the YTS / Yify api (version 2)
 
-This PHP class makes use of the YTS / Yify api v2 which can be found on [YTS.to]. It's extremely easy to setup and use. For more info see the examples below.
+This PHP class makes use of the YTS / Yify api v2 which can be found on [YTS.ag]. It's extremely easy to setup and use. For more info see the examples below.
 
 ## Functions
 This project is a work in progress. It only uses basic movie functionality for now. Here is the list of supported functions
@@ -84,5 +84,4 @@ if($movies){
 ## License
 See License.md
 
-[YTS.to]:https://yts.to/api
-
+[YTS.ag]:https://yts.ag/api

--- a/inc/YTS.php
+++ b/inc/YTS.php
@@ -12,7 +12,7 @@
  */
 class YTS {
 	
-	const BASE_URL = 'https://yts.to';
+	const BASE_URL = 'https://yts.ag';
 
     /**
      * ListMovies

--- a/inc/YTS.php
+++ b/inc/YTS.php
@@ -11,6 +11,8 @@
  * @license http://opensource.org/licenses/gpl-license.php GNU Public License
  */
 class YTS {
+	
+	const BASE_URL = 'https://yts.to';
 
     /**
      * ListMovies
@@ -29,7 +31,7 @@ class YTS {
      * @throws Exception thrown when HTTP request or API request fails
      */
     public function listMovies($quality = 'All', $limit = 20, $query_term = 0, $page = 1, $minimum_rating = 0, $genre = 'All', $sort_by = 'date-added', $order_by = 'desc', $with_rt_ratings = false){
-        $baseUrl =  'https://yts.to/api/v2/list_movies.json';
+        $baseUrl =  self::BASE_URL . '/api/v2/list_movies.json';
         $parameters = '?limit='.$limit.'&page='.$page.'&quality='.$quality.'&minimum_rating='.$minimum_rating.'&query_term='.$query_term.'&genre='.$genre.'&sort_by='.$sort_by.'&order_by='.$order_by.'&with_rt_ratings='.$with_rt_ratings;
 
         $data = $this->getFromApi($baseUrl.$parameters);
@@ -51,7 +53,7 @@ class YTS {
      * @throws Exception thrown when HTTP request or API request fails
      */
     public function movieDetail($movie_id, $with_images = false, $with_cast=false){
-        $baseUrl = 'https://yts.to/api/v2/movie_details.json';
+        $baseUrl = self::BASE_URL . '/api/v2/movie_details.json';
         $parameters = '?movie_id='.$movie_id.'&with_images'.$with_images.'&with_cast='.$with_cast;
 
         return $this->getFromApi($baseUrl.$parameters);
@@ -66,7 +68,7 @@ class YTS {
      * @throws Exception thrown when HTTP request or API request fails
      */
     public function movieSuggestions($movie_id){
-        $baseUrl = 'https://yts.to/api/v2/movie_suggestions.json?movie_id='.$movie_id;
+        $baseUrl = self::BASE_URL . '/api/v2/movie_suggestions.json?movie_id='.$movie_id;
 
         $data = $this->getFromApi($baseUrl);
 
@@ -85,7 +87,7 @@ class YTS {
      * @throws Exception thrown when HTTP request or API request fails
      */
     public function movieComments($movie_id){
-        $baseUrl = 'https://yts.to/api/v2/movie_comments.json?movie_id='.$movie_id;
+        $baseUrl = self::BASE_URL . '/api/v2/movie_comments.json?movie_id='.$movie_id;
 
         $data = $this->getFromApi($baseUrl);
 
@@ -104,7 +106,7 @@ class YTS {
      * @throws Exception thrown when HTTP request or API request fails
      */
     public function movieReviews($movie_id){
-        $baseUrl = 'https://yts.to/api/v2/movie_reviews.json?movie_id='.$movie_id;
+        $baseUrl = self::BASE_URL . '/api/v2/movie_reviews.json?movie_id='.$movie_id;
 
         $data = $this->getFromApi($baseUrl);
 
@@ -123,7 +125,7 @@ class YTS {
      * @throws Exception thrown when HTTP request or API request fails
      */
     public function movieParentalGuides($movie_id){
-        $baseUrl = 'https://yts.to/api/v2/movie_parental_guides.json?movie_id='.$movie_id;
+        $baseUrl = self::BASE_URL . '/api/v2/movie_parental_guides.json?movie_id='.$movie_id;
 
         $data = $this->getFromApi($baseUrl);
 
@@ -141,7 +143,7 @@ class YTS {
      * @throws Exception thrown when HTTP request or API request fails
      */
     public function listUpcoming(){
-        $baseUrl = 'https://yts.to/api/v2/list_upcoming.json';
+        $baseUrl = self::BASE_URL . '/api/v2/list_upcoming.json';
 
         $data = $this->getFromApi($baseUrl);
 

--- a/index.php
+++ b/index.php
@@ -28,12 +28,12 @@ if($movies){
  * Example results:
  *
  * Dinosaur Island
- * https://yts.to/torrent/download/25E4030659954C1D1382FEE2ED37F6F670FB3F97.torrent (693.11 MB)
+ * https://yts.ag/torrent/download/25E4030659954C1D1382FEE2ED37F6F670FB3F97.torrent (693.11 MB)
  *
  * Paris, Texas
- * https://yts.to/torrent/download/F4747ECDDB1E0EF43A299CB781941D18D67C2F68.torrent (2.07 GB)
+ * https://yts.ag/torrent/download/F4747ECDDB1E0EF43A299CB781941D18D67C2F68.torrent (2.07 GB)
  * This movie has: Nudity Violence Profanity Alcohol Frightening
  *
  * R.E.M. by MTV
- * https://yts.to/torrent/download/1F28D13F40AE91AECC58D649F5F9D84D29321632.torrent (812.23 MB)
+ * https://yts.ag/torrent/download/1F28D13F40AE91AECC58D649F5F9D84D29321632.torrent (812.23 MB)
  */


### PR DESCRIPTION
As YTS.to is now dead, changed the base URL over to YTS.ag which (although not being the official YTS as they shut down) are still uploading torrents and use the same API structure.